### PR TITLE
Add overlay (for readability)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,50 +1,57 @@
+'use strict'
+
 const { nasaApiKey } = require('./nasa-api-key');
 
 exports.decorateConfig = (config) => {
+  const { overlayColor = '#000', overlayOpacity = .5 } = config.hypernasa || {};
+
   return Object.assign({}, config, {
-    backgroundColor: 'transparent'
+    backgroundColor: 'transparent',
+    css: `
+      ${config.css}
+
+      .hyper_main {
+        background-color: ${overlayColor};
+        background-size: cover;
+        background-position: center;
+      }
+
+      .hyper_main:before {
+        content: '';
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        background-color: ${overlayColor};
+        opacity: ${overlayOpacity};
+      }
+    `
   });
 }
 
-exports.decorateHyper = (Hyper, { React }) => {
-
-  return class extends React.Component {
+exports.decorateHyper = (Hyper, { React }) =>
+  class extends React.Component {
     constructor (props, context) {
       super(props, context);
-      this._fetchImage = this._fetchImage.bind(this);
       this._fetchImage();
     }
 
     _fetchImage () {
-      const potdImageUrl= `https://api.nasa.gov/planetary/apod?api_key=${nasaApiKey}`;
-
-      fetch(potdImageUrl).then((response) => {
-        response.json().then((data) => {
-          this.setState({image: data.hdurl || data.url});
-        });
-      });
+      fetch(`https://api.nasa.gov/planetary/apod?api_key=${nasaApiKey}`)
+        .then((response) => response.json())
+        .then(({ hdurl, url }) => this.setState({ image: hdurl || url }));
     }
 
     render () {
-      let css;
-
-      if (this.state && this.state.image) {
-        css = `
-          .hyper_main {
-            background-image: url(${this.state.image});
-            background-size: cover;
-            background-color: #000;
-          }`;
-      } else {
-        css = `
-          .hyper_main {
-            background-color: #000;
-          }`;
-      }
-
       return React.createElement(Hyper, Object.assign({}, this.props, {
-        customCSS: css
+        customCSS: `
+          ${this.props.customCSS}
+
+          .hyper_main {
+            background-image: url("${this.state && this.state.image}");
+          }
+        `
       }));
     }
-  }
-};
+  };

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,19 @@ A theme which replaces the terminal background with NASA's Picture of the Day. (
 
 Add `hypernasa` to the plugins list in your `~/.hyper.js` config file.
 
+## Options
+
+*~/.hyper.js*
+```javascript
+module.exports = {
+  config: {
+    hypernasa: {
+      overlayColor: #000,
+      overlayOpacity: .25
+    }
+  }
+}
+```
 
 ## License
 


### PR DESCRIPTION
Adds a configurable overlay to increase legibility

__0%__
<img width="958" alt="screenshot 2017-01-19 10 41 28" src="https://cloud.githubusercontent.com/assets/5419074/22115774/f3764b78-de33-11e6-88b8-3220d6b4e568.png">

__25% (default)__
<img width="958" alt="screenshot 2017-01-19 10 42 55" src="https://cloud.githubusercontent.com/assets/5419074/22115812/106fee96-de34-11e6-90d8-18e51f4f14ed.png">

__60%__
<img width="953" alt="screenshot 2017-01-19 10 42 01" src="https://cloud.githubusercontent.com/assets/5419074/22115773/f3725c34-de33-11e6-94c8-3da0df7e6dd3.png">

Also:
- centers background image
- fixes #4 
- refactors some (to access config object and make play nice with other custom css)